### PR TITLE
Fix infinite loop of `tns run`

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -8,22 +8,22 @@ var glob = require('glob');
 function convert(logger, projectDir, options) {
 	return new Promise(function (resolve, reject) {
 		options = options || {};
-		
+
 		var lessFilesPath = path.join(projectDir, 'app/**/*.less');
 		var lessFiles = glob.sync(lessFilesPath).filter(function(fileName){
 			return fileName.indexOf("App_Resources") === -1;
-		});    
-    
+		});
+
 		var i = 0;
 		var loopLessFilesAsync = function(lessFiles){
 			parseLess(lessFiles[i], function(e){
 				if(e !== undefined){
 					//Error in the LESS parser; Reject promise
-					reject(Error(lessFiles[i] + ' LESS CSS pre-processing failed. Error: ' + e));  
+					reject(Error(lessFiles[i] + ' LESS CSS pre-processing failed. Error: ' + e));
 				}
-        
+
 				i++; //Increment loop counter
-        
+
 				if(i < lessFiles.length){
 					loopLessFilesAsync(lessFiles);
 				} else {
@@ -32,7 +32,7 @@ function convert(logger, projectDir, options) {
 				}
 			});
 		}
-    
+
 		loopLessFilesAsync(lessFiles);
 	});
 }
@@ -47,13 +47,17 @@ function parseLess(filePath, callback){
 		if(e) {
 			//Callback with error
 			callback(e);
-		}           
-    
+		}
+
 		var cssFilePath = filePath.replace('.less', '.css');
 
-		fs.writeFile(cssFilePath, output.css, 'utf8', function(){
-			//File done writing
-			callback();
-		});                       
+		var currentContent = fs.existsSync(cssFilePath) ? fs.readFileSync(cssFilePath).toString() : null;
+		if (currentContent !== output.css) {
+			// Overwrite file only in case the new content is not the same as current one.
+			// This prevents infinite loop of `tns run` command.
+			fs.writeFileSync(cssFilePath, output.css, 'utf8');
+		}
+
+		callback();
 	});
 }


### PR DESCRIPTION
When you have devices with different platorm, since NativeScript CLI 3.1.3, you can use `tns run` command to run your app simultaneously on all devices.
However, when a change is applied, CLI prepares the project for the first platform (for example iOS) and syncs it to all available iOS devices and simulators.
After that, the project is prepared for the other platform (Android in this case) and syncs the changes to all available Android devices and emulators.
The first prepare (for iOS) will parse all `.less` files and will create `.css` files for each of them.
The second prepare (for Android) will do the same and will rewrite the files. At this point CLI is watching for file changes and will detect the new `.css` files (they have the same content, but they are newly created files, as the plugin is always writing) and will trigger new prepare steps.
And this continues indefinetely.
In order to fix it, check the content of the output.css file with the current content of the file and if they are the same, do not overwrite the file.
This way the first prepare (for iOS) will create all `.css` files, the prepare for Android will not overwrite them and CLI will not go into infinite loop.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3017

NOTE: PR targets the `patch-1` branch as it seems latest version of the plugin is published from it.